### PR TITLE
Improve "Get in touch" section content and layout - closes #70

### DIFF
--- a/components/Section/ContactSection.tsx
+++ b/components/Section/ContactSection.tsx
@@ -1,13 +1,13 @@
 import Grid, { GridDirection } from '@material-ui/core/Grid'
 import { useTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
-//import Button from '../../components/Button/Button'
 import useTranslation from '../../hooks/useTranslation'
 import TextSection from './TextSection'
 import ChatIcon from '@material-ui/icons/Chat'
+import Link from 'next/link'
 
 export default function ContactSection() {
-  const { t } = useTranslation()
+  const { locale, t } = useTranslation()
   const chatIconStyleFirst = { fontSize: 180, color: 'var(--pink)' }
   const chatIconStyleSecond = {
     fontSize: 100,
@@ -36,22 +36,51 @@ export default function ContactSection() {
         </Grid>
         <Grid item xs={12} md={5}>
           <h2>{t('homepage.getInTouch.title')}</h2>
-          <p>{t('homepage.getInTouch.description')}</p>
-          <p>{t('homepage.getInTouch.description2')}</p>
-          <br />
-          <p>{t('homepage.getInTouch.description3')}</p>
-          <br />
-          <br />
-          <Grid container justify='space-between'>
-            <Grid item xs={6}>
-              {/* <Button href='https://opentechschool-slack.herokuapp.com'>
-                {t('homepage.getInTouch.slack')}
-              </Button> */}
-            </Grid>
-            <Grid item xs={6}>
-              {/* <Button href='mailto:'>{t('homepage.getInTouch.email')}</Button> */}
-            </Grid>
-          </Grid>
+          <ul className='content'>
+            <li>
+              <h4 className='subHeading'>
+                {t('homepage.getInTouch.events.title')}
+              </h4>
+              <p>{t('homepage.getInTouch.events.description')}</p>
+              <p>
+                <Link href={`/[lang]#events`} as={`/${locale}#events`}>
+                  <a className='primaryLink'>
+                    {t('homepage.getInTouch.events.cta')}
+                  </a>
+                </Link>
+              </p>
+            </li>
+            <li>
+              <h4 className='subHeading'>
+                {t('homepage.getInTouch.slack.title')}
+              </h4>
+              <p>{t('homepage.getInTouch.slack.description')}</p>
+              <p>
+                <a
+                  className='primaryLink'
+                  href='https://opentechschool-slack.herokuapp.com/'
+                  target='_blank'
+                  rel='noopener'
+                >
+                  {t('homepage.getInTouch.slack.cta')}
+                </a>
+              </p>
+            </li>
+            <li>
+              <h4 className='subHeading'>
+                {t('homepage.getInTouch.email.title')}
+              </h4>
+              <p>{t('homepage.getInTouch.email.description')}</p>
+              <p>
+                <a
+                  className='primaryLink'
+                  href='mailto:info@opentechschool.org'
+                >
+                  {t('homepage.getInTouch.email.cta')}
+                </a>
+              </p>
+            </li>
+          </ul>
         </Grid>
       </Grid>
       <style jsx>{`
@@ -59,6 +88,18 @@ export default function ContactSection() {
           text-align: center;
           width: 300px;
           margin-top: 20px;
+        }
+        .subHeading {
+          padding-bottom: calc(1.45rem / 2); /* same as li > p */
+        }
+        .content :global(li:first-child) .subHeading:first-child {
+          padding-top: 0;
+        }
+        .primaryLink {
+          color: var(--pink);
+        }
+        .primaryLink:hover {
+          color: var(--mainBlue);
         }
       `}</style>
     </TextSection>

--- a/components/Section/ContactSection.tsx
+++ b/components/Section/ContactSection.tsx
@@ -5,6 +5,7 @@ import useTranslation from '../../hooks/useTranslation'
 import TextSection from './TextSection'
 import ChatIcon from '@material-ui/icons/Chat'
 import Link from 'next/link'
+import { mediaquery } from '../../style/style.js'
 
 export default function ContactSection() {
   const { locale, t } = useTranslation()
@@ -88,6 +89,12 @@ export default function ContactSection() {
           text-align: center;
           width: 300px;
           margin-top: 20px;
+          display: none;
+        }
+        @media (${mediaquery.tabletToDesktop}) {
+          .message-icons {
+            display: initial;
+          }
         }
         .subHeading {
           padding-bottom: calc(1.45rem / 2); /* same as li > p */

--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -178,7 +178,9 @@ export const Index: NextPage = () => {
       <TextSection title={t('chapter.title')} anchor='find-events'>
         <ChapterSection />
 
-        <h4 className='chapter-events'>{t('chapter.events')}</h4>
+        <h4 className='chapter-events' id='events'>
+          {t('chapter.events')}
+        </h4>
         <Events
           title={t('city.suggestEvent')}
           events={events}

--- a/translations/en.json
+++ b/translations/en.json
@@ -39,11 +39,21 @@
     },
     "getInTouch": {
       "title": "Get in touch",
-      "description": "The best way to get in touch with the community is at one of our local event. Feel free to join anytime.",
-      "description2": "You can also get in touch via Slack where we share information beyond the events.",
-      "description3": "If you have a general question about the OpenTechSchool you can also send us an email.",
-      "slack": "Join our Slack",
-      "email": "Send an email"
+      "events": {
+        "title": "At our events",
+        "description": "The best way to get in touch with the community is at our events. Just come by, feel the vibe and speak to one of the organizers. Nice to meet you!",
+        "cta": "Check out upcoming events"
+      },
+      "slack": {
+        "title": "Online chat",
+        "description": "We are using Slack to connect and share information beyond the events. Say hi in the #general channel or find the one for your city.",
+        "cta": "Join our Slack"
+      },
+      "email": {
+        "title": "Email",
+        "description": "Contact us directly if you have a general question and the above options are not working for you. We love to hear from you, but remember we are all volunteers and might need some time to reply.",
+        "cta": "Send an email"
+      }
     }
   },
   "chapter": {


### PR DESCRIPTION
Other than in the issue I linked to the upcoming events section from the first item, not to the community page.

![Bildschirmfoto 2020-03-21 um 20 13 54](https://user-images.githubusercontent.com/112532/77235765-ee09de00-6bb8-11ea-8663-be18ce7c960e.png)
