### PR TITLE
hide language switcher

### DIFF
--- a/components/LocalSwitcher/LocalSwitcher.tsx
+++ b/components/LocalSwitcher/LocalSwitcher.tsx
@@ -3,8 +3,15 @@ import { useRouter } from 'next/dist/client/router'
 import MenuItem from '@material-ui/core/MenuItem'
 import FormControl from '@material-ui/core/FormControl'
 import Select from '@material-ui/core/Select'
+import { withStyles } from '@material-ui/core/styles'
 import { locales, languageNames } from '../../translations/config'
 import { LocaleContext } from '../../context/LocaleContext'
+
+const MenuItemStyle = withStyles({
+  root: {
+    fontSize: '1.4rem',
+  },
+})(MenuItem)
 
 const LocaleSwitcher: React.FC = () => {
   const router = useRouter()
@@ -24,11 +31,16 @@ const LocaleSwitcher: React.FC = () => {
   return (
     <section>
       <FormControl>
-        <Select value={locale} onChange={handleLocaleChange} displayEmpty>
+        <Select
+          className='localSwitch-select'
+          value={locale}
+          onChange={handleLocaleChange}
+          displayEmpty
+        >
           {locales.map(locale => (
-            <MenuItem key={locale} value={locale}>
+            <MenuItemStyle key={locale} value={locale}>
               {languageNames[locale]}
-            </MenuItem>
+            </MenuItemStyle>
           ))}
         </Select>
       </FormControl>
@@ -38,8 +50,15 @@ const LocaleSwitcher: React.FC = () => {
           display: flex;
           min-height: 50px;
           align-items: center;
-          justify-content: flex-end;
           padding: 0 20px;
+        }
+
+        section :global(.localSwitch-select) {
+          font-size: 1.4rem;
+        }
+
+        section :global(li.localSwitch-select svg) {
+          font-size: 20px;
         }
       `}</style>
     </section>

--- a/hooks/useTranslation.ts
+++ b/hooks/useTranslation.ts
@@ -12,9 +12,9 @@ export default function useTranslation() {
   const DEstrings: Strings = require('../translations/de.json')
 
   switch (locale) {
-    case 'de':
-      strings = DEstrings
-      break
+    // case 'de':
+    //   strings = DEstrings
+    //   break
     default:
       strings = ENstrings
   }

--- a/pages/[lang]/about.tsx
+++ b/pages/[lang]/about.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next'
 import PageLayout from '../../components/PageLayout/PageLayout'
 import Grid from '@material-ui/core/Grid'
 import TextSection from '../../components/Section/TextSection'
-import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
 import Button from '../../components/Button/Button'
 import useTranslation from '../../hooks/useTranslation'
 import WithLocale from '../../containers/withLocale'
@@ -16,9 +16,9 @@ const About: NextPage = () => {
       siteTitle='about.siteTitle'
       siteDescription={t('about.siteDescription')}
     >
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
       <TextSection
         classname='default'
         title={t('about.history.title')}

--- a/pages/[lang]/city/[slug].js
+++ b/pages/[lang]/city/[slug].js
@@ -10,7 +10,7 @@ import GitHubIcon from '@material-ui/icons/GitHub'
 import TwitterIcon from '@material-ui/icons/Twitter'
 import useTranslation from '../../../hooks/useTranslation'
 import WithLocale from '../../../containers/withLocale'
-import LocalSwitcher from '../../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../../components/LocalSwitcher/LocalSwitcher'
 import CityLayout from '../../../components/CityLayout/CityLayout'
 import CityHero from '../../../components/CityHero/CityHero'
 import TextSection from '../../../components/Section/TextSection'
@@ -79,9 +79,9 @@ export function CityTemplate({ content, data, siteTitle, siteDescription }) {
         meetupName={frontmatter.meetup_name}
         credits={frontmatter.credits}
       />
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
       <TextSection classname='default'>
         <Grid
           container

--- a/pages/[lang]/community.tsx
+++ b/pages/[lang]/community.tsx
@@ -3,7 +3,7 @@ import { NextPage } from 'next'
 import Link from 'next/link'
 import PageLayout from '../../components/PageLayout/PageLayout'
 import ChapterSection from '../../components/Section/ChapterSection'
-import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
 import useTranslation from '../../hooks/useTranslation'
 import WithLocale from '../../containers/withLocale'
 import TextSection from '../../components/Section/TextSection'
@@ -17,9 +17,9 @@ const Community: NextPage = () => {
       siteTitle={t('community.siteTitle')}
       siteDescription={t('community.siteDescription')}
     >
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
 
       <TextSection title='Community'>
         <Grid container justify='center' alignItems='center'>

--- a/pages/[lang]/contribute.tsx
+++ b/pages/[lang]/contribute.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next'
 import Grid from '@material-ui/core/Grid'
 import Link from 'next/link'
 import PageLayout from '../../components/PageLayout/PageLayout'
-import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
 import useTranslation from '../../hooks/useTranslation'
 import WithLocale from '../../containers/withLocale'
 import TextSection from '../../components/Section/TextSection'
@@ -16,9 +16,9 @@ const Community: NextPage = () => {
       siteTitle={t('contribute.siteTitle')}
       siteDescription={t('contribute.siteDescription')}
     >
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
 
       <TextSection title={t('contribute.contribute.title')}>
         <Grid container justify='center' alignItems='center'>

--- a/pages/[lang]/guides.tsx
+++ b/pages/[lang]/guides.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next'
 import Grid from '@material-ui/core/Grid'
 import Link from 'next/link'
 import PageLayout from '../../components/PageLayout/PageLayout'
-import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
 import useTranslation from '../../hooks/useTranslation'
 import WithLocale from '../../containers/withLocale'
 import TextSection from '../../components/Section/TextSection'
@@ -15,9 +15,9 @@ const Guides: NextPage = () => {
       siteTitle={t('guides.siteTitle')}
       siteDescription={t('guides.siteDescription')}
     >
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
 
       <TextSection title='Guides'>
         <Grid container justify='space-between'>

--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -9,7 +9,7 @@ import useTranslation from '../../hooks/useTranslation'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import WithLocale from '../../containers/withLocale'
 import PageLayout from '../../components/PageLayout/PageLayout'
-import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
+// import LocalSwitcher from '../../components/LocalSwitcher/LocalSwitcher'
 import TextSection from '../../components/Section/TextSection'
 import ChapterSection, { cities } from '../../components/Section/ChapterSection'
 import Button from '../../components/Button/Button'
@@ -76,9 +76,9 @@ export const Index: NextPage = () => {
     >
       <Masthead />
 
-      <section>
+      {/* <section>
         <LocalSwitcher />
-      </section>
+      </section> */}
 
       <TextSection>
         <Grid container justify='space-between' alignItems='center'>

--- a/translations/config.ts
+++ b/translations/config.ts
@@ -1,8 +1,7 @@
 export const defaultLocale = 'en' as const
 
-export const locales = ['en', 'de'] as const
+export const locales = ['en'] as const
 
 export const languageNames = {
   en: 'English',
-  de: 'Deutsch',
 }

--- a/translations/getInitialLocale.ts
+++ b/translations/getInitialLocale.ts
@@ -13,7 +13,5 @@ export function getInitialLocale(): Locale {
   if (isLocale(browserSetting)) {
     return browserSetting
   }
-
-  console.log('default')
   return defaultLocale
 }


### PR DESCRIPTION
- hide language switch from all the pages
- modify `translations/config.ts` and `hooks/useTranslation.ts` to hide `de` string
- improve language switcher style for when we will show again :) 

close #90 