### PR TITLE
Fix line breaks

### DIFF
--- a/style/style-global.js
+++ b/style/style-global.js
@@ -36,7 +36,6 @@ export default css.global`
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     word-break: break-word;
-    white-space: pre-line;
     font-size: 18px;
     font-size: 1.8rem;
     letter-spacing: -0.5px;


### PR DESCRIPTION

![Bildschirmfoto 2020-04-15 um 20 37 15](https://user-images.githubusercontent.com/112532/79378512-c579c780-7f5d-11ea-9ee2-6a9a734a06f5.png)


Berlin city page had weird line breaks. The global "pre-line" white space setting seems to be too dangerous and unexpected to me.