### PR TITLE
feat: lazyload twitterfeed on intersection

### DIFF
--- a/components/TwitterFeed.tsx
+++ b/components/TwitterFeed.tsx
@@ -1,32 +1,48 @@
+import { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import useTranslation from '../hooks/useTranslation'
 import TextSection from '../components/Section/TextSection'
 import { TwitterTimelineEmbed } from 'react-twitter-embed'
+import useIntersectionObserver from '../hooks/useIntersectionObserver'
 
 const TwitterFeed = ({ screenName }) => {
   const { t } = useTranslation()
+  const twitterFeedContainer = useRef()
+  const [isTwitterFeedVisible, setTwitterFeedVisible] = useState(false)
+
+  useIntersectionObserver({
+    target: twitterFeedContainer,
+    rootMargin: '100px',
+    onIntersect: ([{ isIntersecting }]) => {
+      setTwitterFeedVisible(isIntersecting)
+    },
+  })
 
   return (
-    <TextSection classname='grey' title='Tweets'>
-      <div className='wrapper'>
-        <div className='tweets-from'>
-          {t('twitterfeed.tweetsFrom')}{' '}
-          <a
-            href={`https://twitter.com/${screenName}`}
-            target='_blank'
-            rel='noopener noreferrer'
-          >
-            @{screenName}
-          </a>
-        </div>
-        <TwitterTimelineEmbed
-          sourceType='profile'
-          screenName={screenName}
-          noFooter={true}
-          noHeader={true}
-          options={{ height: 600 }}
-        />
-      </div>
+    <div ref={twitterFeedContainer}>
+      {isTwitterFeedVisible && (
+        <TextSection classname='grey' title='Tweets'>
+          <div className='wrapper'>
+            <div className='tweets-from'>
+              {t('twitterfeed.tweetsFrom')}{' '}
+              <a
+                href={`https://twitter.com/${screenName}`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                @{screenName}
+              </a>
+            </div>
+            <TwitterTimelineEmbed
+              sourceType='profile'
+              screenName={screenName}
+              noFooter={true}
+              noHeader={true}
+              options={{ height: 600 }}
+            />
+          </div>
+        </TextSection>
+      )}
       <style jsx>{`
         .wrapper {
           max-width: 600px;
@@ -43,7 +59,7 @@ const TwitterFeed = ({ screenName }) => {
           text-align: center;
         }
       `}</style>
-    </TextSection>
+    </div>
   )
 }
 

--- a/components/TwitterFeed.tsx
+++ b/components/TwitterFeed.tsx
@@ -14,7 +14,9 @@ const TwitterFeed = ({ screenName }) => {
     target: twitterFeedContainer,
     rootMargin: '100px',
     onIntersect: ([{ isIntersecting }]) => {
-      setTwitterFeedVisible(isIntersecting)
+      if (!isTwitterFeedVisible) {
+        setTwitterFeedVisible(isIntersecting)
+      }
     },
   })
 

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -7,23 +7,22 @@ const useIntersectionObserver = ({
   rootMargin = '0px',
 }) => {
   useEffect(() => {
+    if (!window.IntersectionObserver) {
+      return
+    }
+
     const observer = new IntersectionObserver(onIntersect, {
       rootMargin,
       threshold,
     })
 
-    if (!target) {
-      console.warn('No target specified for Intersection Observer')
-      return
-    }
-
-    observer.observe(target.current);
+    observer.observe(target.current)
 
     // Let's clean up after ourselves.
     return () => {
-      observer.unobserve(target.current);
+      observer.unobserve(target.current)
     }
-  })
+  }, [target.current])
 }
 
 export default useIntersectionObserver

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+const useIntersectionObserver = ({
+  target,
+  onIntersect,
+  threshold = 1.0,
+  rootMargin = '0px',
+}) => {
+  useEffect(() => {
+    const observer = new IntersectionObserver(onIntersect, {
+      rootMargin,
+      threshold,
+    })
+
+    if (!target) {
+      console.warn('No target specified for Intersection Observer')
+      return
+    }
+
+    observer.observe(target.current);
+
+    // Let's clean up after ourselves.
+    return () => {
+      observer.unobserve(target.current);
+    }
+  })
+}
+
+export default useIntersectionObserver


### PR DESCRIPTION
To reduce the huge amount of requests on the startpage i wrapped the TwitterFeed in an IntersectionObeserver. This brings the number of initial requests down to 27 from ~115. I'm looking to bring in a fallback/polyfill solution for older browsers that don't support IntersectionObserver as a follow up.