### PR TITLE
Fix material UI ssr

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ import useTranslation from '../../hooks/useTranslation'
 import { mediaquery } from '../../style/style'
 
 export default function Footer() {
-  const { locale, t } = useTranslation()
+  const { t } = useTranslation()
 
   return (
     <footer>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { useState } from 'react'
 import PropTypes from 'prop-types'
 import Meta from '../Meta'
@@ -5,14 +6,12 @@ import Header from '../Header/Header'
 import Footer from '../Footer/Footer'
 
 import globalStyle from '../../style/style-global'
-import { ThemeProvider } from '@material-ui/core/styles'
-import { otsTheme } from '../../style/style'
 
 export const Layout = ({ pageTitle, pageDescription, children }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
-    <ThemeProvider theme={otsTheme}>
+    <React.Fragment>
       <Meta pageTitle={pageTitle} pageDescription={pageDescription} />
       <div className={isMenuOpen ? 'bodyFixed' : ''}>
         <Header setIsMenuOpen={setIsMenuOpen} />
@@ -28,7 +27,7 @@ export const Layout = ({ pageTitle, pageDescription, children }) => {
           }
         `}</style>
       </div>
-    </ThemeProvider>
+    </React.Fragment>
   )
 }
 

--- a/components/Section/ChapterSection.tsx
+++ b/components/Section/ChapterSection.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import matter from 'gray-matter'
 import Grid from '@material-ui/core/Grid'
 import PropTypes from 'prop-types'
-import useTranslation from '../../hooks/useTranslation'
 import { mediaquery } from '../../style/style'
 
 export const cities = (ctx => {
@@ -25,8 +24,6 @@ export default function ChapterSection({
   hideActiveChapters,
   hideInactiveChapters,
 }) {
-  const { locale } = useTranslation()
-
   return (
     <div className='chaptersWrapper'>
       {title ? <h4>{title}</h4> : ''}

--- a/components/Section/ContactSection.tsx
+++ b/components/Section/ContactSection.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 import { mediaquery } from '../../style/style.js'
 
 export default function ContactSection() {
-  const { locale, t } = useTranslation()
+  const { t } = useTranslation()
   const chatIconStyleFirst = { fontSize: 180, color: 'var(--pink)' }
   const chatIconStyleSecond = {
     fontSize: 100,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ThemeProvider } from '@material-ui/core/styles'
+import { otsTheme } from '../style/style'
+
+export default function MyApp(props) {
+  const { Component, pageProps } = props
+
+  React.useEffect(() => {
+    // This allows to use material UI with SSR: https://itnext.io/next-js-with-material-ui-7a7f6485f671
+
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side')
+    if (jssStyles) {
+      jssStyles.parentElement.removeChild(jssStyles)
+    }
+  }, [])
+
+  return (
+    <React.Fragment>
+      <ThemeProvider theme={otsTheme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </React.Fragment>
+  )
+}
+
+MyApp.propTypes = {
+  Component: PropTypes.elementType.isRequired,
+  pageProps: PropTypes.object.isRequired,
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheets } from '@material-ui/core/styles'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang='en'>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+// This allows to use material UI with SSR: https://itnext.io/next-js-with-material-ui-7a7f6485f671
+
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with server-side generation (SSG).
+MyDocument.getInitialProps = async ctx => {
+  // Render app and page and get the context of the page with collected side effects.
+  const sheets = new ServerStyleSheets()
+  const originalRenderPage = ctx.renderPage
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: App => props => sheets.collect(<App {...props} />),
+    })
+
+  const initialProps = await Document.getInitialProps(ctx)
+
+  return {
+    ...initialProps,
+    // Styles fragment is rendered after the app and page rendering finish.
+    styles: [
+      ...React.Children.toArray(initialProps.styles),
+      sheets.getStyleElement(),
+    ],
+  }
+}

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -11,7 +11,7 @@ function ErrorPage({ errorCode }) {
     case 200: // Also display a 404 if someone requests /_error explicitly
     case 404:
       return (
-        <PageLayout pageTitle={t('404.pageTitle')}>
+        <PageLayout pageTitle={t('404.pageTitle')} pageDescription={''}>
           <div className='error'>
             {t('404.description')}
             <br />


### PR DESCRIPTION
The Material UI styles don't work with SSR. When reloading the page the Button styles are missing.

Read more about material ui + ssr: https://material-ui.com/guides/server-rendering/

I used this example to fix the issue: https://itnext.io/next-js-with-material-ui-7a7f6485f671

I am not 100% sure what it's doing and why we need this but it fixes the issue.
