### PR TITLE
Fix links to Code of Conduct

### DIFF
--- a/data/cities/de/leipzig.md
+++ b/data/cities/de/leipzig.md
@@ -27,7 +27,7 @@ Wir treffen uns regelmäßig Montag oder Donnerstag zwischen 19 und 22 Uhr im Ba
 
 Die Veranstaltung ist kostenlos und jeder ist herzlich eingeladen teilzunehmen. Wir bieten keine fortlaufenden Programmierworkshops an, aber wir treffen uns um deine Fragen zu beantworten und dich beim Lernen zu unterstützen. Die Teilnehmer unseres Meetups haben unterschiedliche Erfahrungsbereiche und helfen dir gerne weiter.
 
-Bitte lies unseren [Code of Conduct]({{site.baseurl}}/code-of-conduct/) bevor du vorbei kommst.
+Bitte lies unseren [Code of Conduct](/code-of-conduct/) bevor du vorbei kommst.
 
 Vielen Dank auch an das [Basislager](https://www.basislager.co) für die Bereitstellung der Räumlichkeiten.
 

--- a/data/cities/de/zurich.md
+++ b/data/cities/de/zurich.md
@@ -23,7 +23,7 @@ In den Wintermonaten treffen wir auch am Sonntag Abend von 17:30 bis 19:30 Uhr.
 
 Die Veranstaltung ist kostenlos und jeder ist herzlich willkommen. Wir bieten keine regelmässigen Programmier-Workshops an, aber bei unsere Treffen werden Programmierporblemen besprochen und alle möglichen Fragen gestellt, die beim Einstieg in die Programmierung auftauchen können. Die Teilnehmer, haben unterschiedliche Erfahrungsbereiche und Niveaus und helfen dir gerne weiter.
 
-Bitte lies unseren [Code of Conduct]({{site.baseurl}}/code-of-conduct/) bevor du vorbei kommst.
+Bitte lies unseren [Code of Conduct](/code-of-conduct/) bevor du vorbei kommst.
 
 Herzlichen Dank an [Liip](https://liip.ch) für die Bereitstellung der Räumlichkeiten.
 

--- a/data/cities/en/leipzig.md
+++ b/data/cities/en/leipzig.md
@@ -30,7 +30,7 @@ We meet every week Monday or Thursday between 7 and 10pm at Basislager to learn,
 
 The event is free and everyone is welcome to participate. We don't offer regular coding workshops, but we meet to talk about coding issues or any kind of question you might have when getting started with programming. People that join our meetup have different experience levels and are always happy to help.
 
-Please read our [Code of Conduct]({{site.baseurl}}/code-of-conduct/) before you join.
+Please read our [Code of Conduct](/code-of-conduct/) before you join.
 
 Also a big thanks to [Basislager](https://www.basislager.co) for sponsoring the event space.
 

--- a/data/cities/en/zurich.md
+++ b/data/cities/en/zurich.md
@@ -26,7 +26,7 @@ During the winter months, we also meet on Sunday evenings from 17:30 to 19:30.
 
 The event is free and everyone is welcome to participate. We don't offer regular coding workshops, but we meet to talk about coding issues or any kind of question you might have when getting started with programming. People that join our meetup have different experience levels and are always happy to help.
 
-Please read our [Code of Conduct]({{site.baseurl}}/code-of-conduct/) before you join.
+Please read our [Code of Conduct](/code-of-conduct/) before you join.
 
 A big thanks to [Liip](https://liip.ch) for sponsoring the event space.
 


### PR DESCRIPTION
`{{site.baseurl}}` seems to be a legacy thing from Jekyll.